### PR TITLE
Refactor CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,30 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.13...3.28)
 
-cmake_policy(SET CMP0076 NEW)
+project(mmpld_io
+    LANGUAGES CXX)
 
-project(mmpld_io)
-
+# Library
 file(GLOB_RECURSE header_files RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "include/*.h")
 
 add_library(mmpld_io INTERFACE)
-target_sources(mmpld_io INTERFACE ${header_files})
+add_library(mmpld_io::mmpld_io ALIAS mmpld_io)
+target_sources(mmpld_io PRIVATE ${header_files})
+include(GNUInstallDirs)
 target_include_directories(mmpld_io INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/mmpld_io>
 )
-install(FILES ${header_files} DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
 
+# Install
+install(FILES ${header_files} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/mmpld_io")
+install(TARGETS mmpld_io EXPORT mmpld_ioTargets)
+install(EXPORT mmpld_ioTargets
+    FILE mmpld_ioConfig.cmake
+    NAMESPACE mmpld_io::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mmpld_io
+)
 
+# Test
 option(BUILD_TEST "Build test exe" OFF)
 
 if (BUILD_TEST)


### PR DESCRIPTION
- Install a CMake config file to support find_package(mmpld_io)
- Add namespaced alias target
- Install to mmpld_io subdir to not polute global include folder as this library has pretty generic filenames
- Raise CMake minimum to 3.13, as CMP0076 was required anyway.
- Make target sources a PRIVATE dependency otherwise interfers with target install. Is anyway required only for VS to show the files.